### PR TITLE
build: modularize tsconfig.json and fix husky hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint:tsc
-npm test
-npm run test:integration
+npm run tsc
+npm run test:ci
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -5,15 +5,16 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "lib/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "clean": "rm -rf coverage lib",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts .",
     "lint:fix": "npm run lint -- --fix",
     "postinstall": "husky install",
     "postpublish": "pinst --enable",
     "prepublishOnly": "pinst --disable && npm run lint && npm run tsc && npm run test:ci && npm run clean && npm run build",
-    "test": "jest --watch",
+    "test": "jest",
     "test:ci": "jest --ci --colors --coverage",
+    "test:watch": "jest --watch",
     "tsc": "tsc --noEmit"
   },
   "repository": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,5 @@
     "strict": true,
     "outDir": "lib"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

- build: modularize `tsconfig.build.json` from `tsconfig.json`
- chore: fix husky hooks

## What is the current behavior?

- tsc does not type check tests
- pre-commit broken due to invalid commands

## What is the new behavior?

- tsc type checks tests
- pre-commit fixed

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)