### PR TITLE
feat: allow custom API endpoint to be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,44 @@ async function main() {
 main()
 ```
 
-TypeScript users can import the types:
+### API Endpoint
+
+There are two endpoints to send requests based on your usage.
+
+| Endpoint                        | Description                                         |
+| ------------------------------- | --------------------------------------------------- |
+| https://api.paccurate.io/       | 30-second timeout, best for real-time (default)     |
+| https://cloud.api.paccurate.io/ | 1 hour timeout, best for large, parallel batch jobs |
+
+Instantiating class with endpoint:
+
+```ts
+import { Paccurate } from 'paccurate'
+
+new Paccurate('YOUR_API_KEY', 'https://cloud.api.paccurate.io/')
+await paccurate.pack(data)
+```
+
+Or passing endpoint in method call:
+
+```ts
+import { Paccurate } from 'paccurate'
+
+const paccurate = new Paccurate('YOUR_API_KEY')
+await paccurate.pack(data, 'https://cloud.api.paccurate.io/')
+```
+
+Or passing endpoint in function call:
+
+```ts
+import { pack } from 'paccurate'
+
+await pack(data, 'https://cloud.api.paccurate.io/')
+```
+
+### TypeScript
+
+The following types are available:
 
 ```ts
 import type { Body, Response } from 'paccurate'

--- a/src/Paccurate.test.ts
+++ b/src/Paccurate.test.ts
@@ -17,10 +17,21 @@ beforeEach(() => {
 })
 
 describe('Paccurate', () => {
-  it('sends post request with body and returns response', async () => {
+  it('sends post request to default endpoint', async () => {
     const paccurate = new Paccurate(apiKey)
     expect(await paccurate.pack(body)).toBe(data)
-    expect(mockedPost).toBeCalledWith(body, {
+    expect(mockedPost).toBeCalledWith('https://api.paccurate.io/', body, {
+      headers: {
+        Authorization: `apikey ${apiKey}`,
+      },
+    })
+  })
+
+  it('sends post request to cloud endpoint', async () => {
+    const apiUrl = 'https://cloud.api.paccurate.io/'
+    const paccurate = new Paccurate(apiKey, apiUrl)
+    expect(await paccurate.pack(body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(apiUrl, body, {
       headers: {
         Authorization: `apikey ${apiKey}`,
       },

--- a/src/Paccurate.ts
+++ b/src/Paccurate.ts
@@ -3,22 +3,26 @@ import type { Body } from './types'
 
 export class Paccurate {
   private apiKey: string
+  private apiUrl: string
 
   /**
    * @param apiKey - Paccurate API key.
+   * @param apiUrl - Paccurate API endpoint.
    */
-  constructor(apiKey: string) {
+  constructor(apiKey: string, apiUrl = 'https://api.paccurate.io/') {
     this.apiKey = apiKey
+    this.apiUrl = apiUrl
   }
 
   /**
    * Finds the optimal way to pack a shipment.
    *
    * @param body - Packing configuration.
+   * @param url - Paccurate API endpoint.
    * @returns - Pack response.
    */
-  pack(body: Body) {
-    return post(body, {
+  pack(body: Body, url = this.apiUrl) {
+    return post(url, body, {
       headers: {
         Authorization: `apikey ${this.apiKey}`,
       },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,7 +25,7 @@ describe('Paccurate', () => {
   })
 
   if (PACCURATE_API_KEY && typeof PACCURATE_API_KEY === 'string') {
-    it('sends post request and returns response', async () => {
+    it('sends post request to default endpoint', async () => {
       const paccurate = new Paccurate(PACCURATE_API_KEY)
       const data = await paccurate.pack(body)
       expect(data).toMatchInlineSnapshot(
@@ -67,6 +67,48 @@ describe('Paccurate', () => {
       )
     })
 
+    it('sends post request to cloud endpoint', async () => {
+      const paccurate = new Paccurate(PACCURATE_API_KEY, 'https://cloud.api.paccurate.io/')
+      const data = await paccurate.pack(body)
+      expect(data).toMatchInlineSnapshot(
+        {
+          built: expect.any(String),
+          boxes: expect.any(Array),
+          packTime: expect.any(Number),
+          renderTime: expect.any(Number),
+          scripts: expect.any(String),
+          styles: expect.any(String),
+          svgs: expect.any(Array),
+          totalTime: expect.any(Number),
+          usedKeyStem: expect.any(String),
+          version: expect.any(String),
+        },
+        `
+        Object {
+          "boxTypeChoiceGoalUsed": "lowest-cost",
+          "boxes": Any<Array>,
+          "built": Any<String>,
+          "host": "cloud.api.paccurate.io",
+          "itemSortUsed": "none",
+          "leftovers": Array [],
+          "lenBoxes": 1,
+          "lenItems": 3,
+          "lenLeftovers": 0,
+          "packTime": Any<Number>,
+          "renderTime": Any<Number>,
+          "scripts": Any<String>,
+          "styles": Any<String>,
+          "svgs": Any<Array>,
+          "title": "Default",
+          "totalCost": 2550,
+          "totalTime": Any<Number>,
+          "usedKeyStem": Any<String>,
+          "version": Any<String>,
+        }
+      `,
+      )
+    })
+
     it('responds with error if body is empty', async () => {
       await expect(pack(undefined as unknown as Body)).rejects.toMatchObject({
         code: 400,
@@ -82,7 +124,7 @@ describe('pack', () => {
   })
 
   if (PACCURATE_API_KEY && typeof PACCURATE_API_KEY === 'string') {
-    it('sends post request and returns response', async () => {
+    it('sends post request to default endpoint', async () => {
       const data = await pack({ ...body, key: PACCURATE_API_KEY })
       expect(data).toMatchInlineSnapshot(
         {
@@ -103,6 +145,50 @@ describe('pack', () => {
           "boxes": Any<Array>,
           "built": Any<String>,
           "host": "api.paccurate.io",
+          "itemSortUsed": "none",
+          "leftovers": Array [],
+          "lenBoxes": 1,
+          "lenItems": 3,
+          "lenLeftovers": 0,
+          "packTime": Any<Number>,
+          "renderTime": Any<Number>,
+          "scripts": Any<String>,
+          "styles": Any<String>,
+          "svgs": Any<Array>,
+          "title": "Default",
+          "totalCost": 2550,
+          "totalTime": Any<Number>,
+          "usedKeyStem": Any<String>,
+          "version": Any<String>,
+        }
+      `,
+      )
+    })
+
+    it('sends post request to cloud endpoint', async () => {
+      const data = await pack(
+        { ...body, key: PACCURATE_API_KEY },
+        'https://cloud.api.paccurate.io/',
+      )
+      expect(data).toMatchInlineSnapshot(
+        {
+          built: expect.any(String),
+          boxes: expect.any(Array),
+          packTime: expect.any(Number),
+          renderTime: expect.any(Number),
+          scripts: expect.any(String),
+          styles: expect.any(String),
+          svgs: expect.any(Array),
+          totalTime: expect.any(Number),
+          usedKeyStem: expect.any(String),
+          version: expect.any(String),
+        },
+        `
+        Object {
+          "boxTypeChoiceGoalUsed": "lowest-cost",
+          "boxes": Any<Array>,
+          "built": Any<String>,
+          "host": "cloud.api.paccurate.io",
           "itemSortUsed": "none",
           "leftovers": Array [],
           "lenBoxes": 1,

--- a/src/pack.test.ts
+++ b/src/pack.test.ts
@@ -16,8 +16,13 @@ beforeEach(() => {
 })
 
 describe('pack', () => {
-  it('sends post request with body and returns response', async () => {
+  it('sends post request to default endpoint', async () => {
     expect(await pack(body)).toBe(data)
-    expect(mockedPost).toBeCalledWith(body)
+    expect(mockedPost).toBeCalledWith('https://api.paccurate.io/', body)
+  })
+
+  it('sends post request to cloud endpoint', async () => {
+    expect(await pack(body, 'https://cloud.api.paccurate.io/')).toBe(data)
+    expect(mockedPost).toBeCalledWith('https://cloud.api.paccurate.io/', body)
   })
 })

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -5,8 +5,9 @@ import type { Body } from './types'
  * Finds the optimal way to pack a shipment.
  *
  * @param body - Packing configuration.
+ * @param url - Paccurate API endpoint.
  * @returns - Pack response.
  */
-export function pack(body: Body) {
-  return post(body)
+export function pack(body: Body, url = 'https://api.paccurate.io/') {
+  return post(url, body)
 }

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -4,15 +4,20 @@ import fetch from 'node-fetch'
 import { post } from './request'
 
 jest.mock('node-fetch')
-
 const mockedFetch = jest.mocked(fetch)
+
+const apiUrl = 'https://api.paccurate.io/'
+const cloudApiUrl = 'https://cloud.api.paccurate.io/'
+
 const body = {
   key: 'apikey',
 }
+
 const response = {
   json: jest.fn(),
   ok: true,
 }
+
 const data = {
   host: 'api.paccurate.io',
 }
@@ -26,22 +31,32 @@ beforeEach(() => {
 
 describe('post', () => {
   describe('success', () => {
-    it('sends a post request to Paccurate API with default options', async () => {
-      expect(await post(body)).toBe(data)
-      expect(mockedFetch).toBeCalledWith('https://api.paccurate.io/', {
+    it('sends a post request to API endpoint with default options', async () => {
+      expect(await post(apiUrl, body)).toBe(data)
+      expect(mockedFetch).toBeCalledWith(apiUrl, {
         body: JSON.stringify(body),
         method: 'POST',
       })
       expect(response.json).toBeCalledTimes(1)
     })
 
-    it('sends a post request to Paccurate API with custom options', async () => {
+    it('sends a post request to API endpoint with custom options', async () => {
       const options = { headers: { Authorization: 'apikey' } }
-      expect(await post(body, options)).toBe(data)
-      expect(mockedFetch).toBeCalledWith('https://api.paccurate.io/', {
+      expect(await post(apiUrl, body, options)).toBe(data)
+      expect(mockedFetch).toBeCalledWith(apiUrl, {
         body: JSON.stringify(body),
         method: 'POST',
         ...options,
+      })
+      expect(response.json).toBeCalledTimes(1)
+    })
+
+    it('sends a post request to cloud API endpoint', async () => {
+      const options = {}
+      expect(await post(cloudApiUrl, body, options)).toBe(data)
+      expect(mockedFetch).toBeCalledWith(cloudApiUrl, {
+        body: JSON.stringify(body),
+        method: 'POST',
       })
       expect(response.json).toBeCalledTimes(1)
     })
@@ -62,7 +77,7 @@ describe('post', () => {
     })
 
     it('responds with error message and code', async () => {
-      const data = post(body)
+      const data = post(apiUrl, body)
       await expect(data).rejects.toBeInstanceOf(Error)
       await expect(data).rejects.toMatchObject(errorData)
       expect(mockedFetch).toBeCalledWith('https://api.paccurate.io/', {

--- a/src/request.ts
+++ b/src/request.ts
@@ -3,23 +3,23 @@ import fetch from 'node-fetch'
 
 import type { Body, Response } from './types'
 
-const method = 'POST'
-const url = 'https://api.paccurate.io/'
-
 class ResponseError extends Error {
   constructor(public code: number, message: string) {
     super(message)
   }
 }
 
+const method = 'POST'
+
 /**
  * Sends a post request to Paccurate API.
  *
+ * @param url - API endpoint.
  * @param body - Packing configuration.
  * @param options - Request options.
  * @returns - Pack response.
  */
-export async function post(body: Body, options?: RequestInit): Promise<Response> {
+export async function post(url: string, body: Body, options?: RequestInit): Promise<Response> {
   const response = await fetch(url, {
     body: JSON.stringify(body),
     method,


### PR DESCRIPTION
## What is the motivation for this pull request?

Resolves #7

## What is the current behavior?

Developer can only make requests to https://api.paccurate.io/

## What is the new behavior?

Developers can pass their own endpoint

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation