### PR TITLE
feat(types): bump Paccurate Swagger version from 1.7.0 to 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,17 @@ The following types can be imported:
 import type { Body, Response } from 'paccurate'
 ```
 
+## Migration
+
+### v2
+
+Updated Paccurate Swagger version from [1.7.0](https://api.paccurate.io/static/api/1.7.0/swagger.yaml) to [1.7.1](https://api.paccurate.io/static/api/1.7.1/swagger.yaml).
+
+**BREAKING CHANGE:** Pack property `key` has been removed from Swagger.
+
 ## Contributing
 
-Contributions are welcome! See our [guide](https://github.com/remarkablemark/paccurate/blob/master/.github/CONTRIBUTING.md) on how to proceed. :wave:
+Contributions are welcome! See our [guide](https://github.com/remarkablemark/paccurate/blob/master/.github/CONTRIBUTING.md) on how to proceed. 👋
 
 ## License
 

--- a/scripts/swagger.sh
+++ b/scripts/swagger.sh
@@ -34,7 +34,7 @@ npm run swagger-to-types
 echo 'Creating PR'
 BRANCH='feat/types'
 git checkout -b $BRANCH
-git commit -am "feat(types): bump paccurate swagger from $PROJECT_VERSION to $LATEST_VERSION"
+git commit -am "feat(types): bump Paccurate Swagger version from $PROJECT_VERSION to $LATEST_VERSION"
 git push origin $BRANCH
 gh pr create --assignee remarkablemark --fill --reviewer remarkablemark
 

--- a/src/Paccurate.test.ts
+++ b/src/Paccurate.test.ts
@@ -4,7 +4,7 @@ import type { Response } from './types'
 
 const mockedPost = jest.mocked(post)
 const apiKey = 'apiKey'
-const body = { key: 'apikey' }
+const body = {}
 const data = { host: 'api.paccurate.io' } as Response
 
 jest.mock('./request', () => ({

--- a/src/index.integration.test.ts
+++ b/src/index.integration.test.ts
@@ -1,5 +1,4 @@
-import { Paccurate, pack } from '.'
-import type { Body } from './types'
+import { type Body, Paccurate, pack, type PackBody } from '.'
 
 const { PACCURATE_API_KEY } = process.env
 
@@ -132,7 +131,7 @@ if (!PACCURATE_API_KEY) {
     })
 
     it('responds with error if body is empty', async () => {
-      await expect(pack(undefined as unknown as Body)).rejects.toMatchObject({
+      await expect(pack(undefined as unknown as PackBody)).rejects.toMatchObject({
         code: 400,
         message: 'EOF',
       })
@@ -248,7 +247,7 @@ if (!PACCURATE_API_KEY) {
     })
 
     it('responds with error if body is empty', async () => {
-      await expect(pack(undefined as unknown as Body)).rejects.toMatchObject({
+      await expect(pack(undefined as unknown as PackBody)).rejects.toMatchObject({
         code: 400,
         message: 'EOF',
       })

--- a/src/pack.test.ts
+++ b/src/pack.test.ts
@@ -3,8 +3,9 @@ import { post } from './request'
 import type { Response } from './types'
 
 const mockedPost = jest.mocked(post)
-const body = { key: 'apikey' }
+const key = 'apikey'
 const data = { host: 'api.paccurate.io' } as Response
+const options = { headers: { Authorization: `apikey ${key}` } }
 
 jest.mock('./request', () => ({
   post: jest.fn(),
@@ -17,12 +18,14 @@ beforeEach(() => {
 
 describe('pack', () => {
   it('sends post request to default endpoint', async () => {
+    const body = { key, boxTypeSets: ['fedex' as const] }
     expect(await pack(body)).toBe(data)
-    expect(mockedPost).toBeCalledWith('https://api.paccurate.io/', body)
+    expect(mockedPost).toBeCalledWith('https://api.paccurate.io/', body, options)
   })
 
   it('sends post request to cloud endpoint', async () => {
+    const body = { key, boxTypeSets: ['fedex' as const] }
     expect(await pack(body, 'https://cloud.api.paccurate.io/')).toBe(data)
-    expect(mockedPost).toBeCalledWith('https://cloud.api.paccurate.io/', body)
+    expect(mockedPost).toBeCalledWith('https://cloud.api.paccurate.io/', body, options)
   })
 })

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -1,6 +1,10 @@
 import { post } from './request'
 import type { Body } from './types'
 
+export interface PackBody extends Body {
+  key: string
+}
+
 /**
  * Finds the optimal way to pack a shipment.
  *
@@ -8,6 +12,9 @@ import type { Body } from './types'
  * @param url - Paccurate API endpoint.
  * @returns - Pack response.
  */
-export function pack(body: Body, url = 'https://api.paccurate.io/') {
-  return post(url, body)
+export function pack(body: PackBody, url = 'https://api.paccurate.io/') {
+  const key = body?.key
+  // @ts-expect-error The operand of a 'delete' operator must be optional.
+  delete body?.key
+  return post(url, body, { headers: { Authorization: `apikey ${key}` } })
 }

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -9,9 +9,7 @@ const mockedFetch = jest.mocked(fetch)
 const apiUrl = 'https://api.paccurate.io/'
 const cloudApiUrl = 'https://cloud.api.paccurate.io/'
 
-const body = {
-  key: 'apikey',
-}
+const body = { boxTypeSets: ['fedex' as const] }
 
 const response = {
   json: jest.fn(),

--- a/src/swagger.yaml
+++ b/src/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 1.7.0
+  version: 1.7.1
   title: paccurate.io
 paths:
   /:
@@ -171,9 +171,6 @@ definitions:
   Pack:
     type: object
     properties:
-      key:
-        description: issued API key.
-        type: string
       requestId:
         description: a client-provided string identifier for the pack request being made.
         type: string
@@ -476,9 +473,10 @@ definitions:
         minLength: 3
         example: [1, 2, 1]
       generatedBoxTypesMax:
-        description: The maximum number of generated box sizes to randomly sampled when generating box types. Default of 0 is unlimited, and in some cases may never return without a limit.
+        description: The maximum number of generated box sizes to randomly sampled when generating box types. Default of 0 is unlimited, and in some cases may never return without a limit. `64` is a sensible value.
         type: integer
         default: 0
+        example: 64
       valueTiebreaker:
         description: The tiebreaker to use in the event to box type choices are otherwise completely equal. Default is "volume", alternative is "weight".
         type: string
@@ -645,12 +643,11 @@ definitions:
         type: boolean
         default: false
       fitForFirstItem:
-        description: if true, select axis length based upon first item placed in each generated box, overriding deriveFromItems and step.
+        description: if true, select axis length based upon first item placed in each generated box, overriding deriveFromItems and increment.
         type: boolean
         default: false
-      step:
-        description: if deriveFromItems is not true, the number of increments to divide the range between min and max into, otherwise ignored.
-        default: 10
+      increment:
+        description: if `deriveFromItems` is not true, the desired increment for box dimension rounding. E.g., `0.25` for a box in inches would round up to the quarter inch. `10` would round to the next even 10s digit. Note that `min` and `max` are included as is, and are not rounded to the nearest `increment`. So, `min 5, max 59, increment 10` could produce any of `[5,10,20,30,40,50,59]` for this `GeneratorAxisRange`. Also note that small `increment` values would benefit from a `generatedBoxTypesMax` set.
         type: number
   GeneratorLimit:
     description: a generator limit for a given calculated box size metric.
@@ -675,9 +672,17 @@ definitions:
       metric:
         $ref: '#/definitions/Metric'
       # limit: allow a limit of times to stack
-      # aggregator: dictate how to aggregate prices when multiple conditions are met
+      aggregator:
+        description: how to aggregate `priceComponents` with common `key` values. `max` selects the largest threshold price across all `priceComponents` sharing a `key`. `product` takes the last (i.e., highest) matching threshold price from each `priceComponent` sharing a `key` and multiplies them together. `sum` simply sums all prices from all matching thresholds across all `priceComponents` sharing the same key. NB all `priceComponents` sharing a `key` must share the same `aggregator` to have predictable behavior.
+        type: string
+        default: max
+        required: false
+        enum:
+          - max
+          - product
+          - sum
       thresholds:
-        description: list of number thresholds of corresponding metric above which corresponding prices are triggered
+        description: list of number thresholds of corresponding metric above which corresponding prices are triggered. Note that thresholds are traversed in reverse in cases where order matters (e.g., when using the `product` aggregator)
         type: array
         items:
           type: number
@@ -698,6 +703,9 @@ definitions:
       - shortest-dimension
       - length-plus-girth
       - girth
+      - x-dimension
+      - y-dimension
+      - z-dimension
   Box:
     description: A completed, packed box.
     allOf:


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(types): bump Paccurate Swagger version from [1.7.0](https://api.paccurate.io/static/api/1.7.0/swagger.yaml) to [1.7.1](https://api.paccurate.io/static/api/1.7.1/swagger.yaml)

https://api.paccurate.io/static/api/

**BREAKING CHANGE:** Pack property `key` has been removed from Swagger

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation